### PR TITLE
Various features/fixes

### DIFF
--- a/js/components/App.js
+++ b/js/components/App.js
@@ -147,7 +147,7 @@ const mainContent = html`
                     </button>
                   </div>
                   <div class="row mt-3">
-                    <div class="btn-group offset-md-3 col-md-6" role="group">
+                    <div class="btn-group overflow-auto offset-md-3 col-md-6" role="group">
                       <button type="button" class="btn btn-secondary" :class="{ active: activeTab == 1 }"
                         @click="changeTab(1)">Equipped</button>
                       <button type="button" class="btn btn-secondary" :class="{ active: activeTab == 2 }"
@@ -241,6 +241,8 @@ const mainContent = html`
             <button type="button" @click="unlockAllWPs" class="btn btn-primary">Unlock All WPs</button>
             <button type="button" @click="setLvl99" class="btn btn-primary">Set Level 99</button>
             <button type="button" @click="setAllSkills20" class="btn btn-primary">Set All Skills 20</button>
+            <button type="button" @click="unlockQs" class="btn btn-primary">Complete Skill/Stat Qs</button>
+            <button type="button" @click="maxGold" class="btn btn-primary">Max Gold</button>
             <br /><br />
             <button type="button" id="d2" class="btn btn-primary" @click="saveFile(0x60)">Save D2</button>
             <button type="button" id="d2r" class="btn btn-primary" @click="saveFile(0x61)">Save D2R</button>
@@ -262,7 +264,7 @@ export default {
     ${mainContent}
   </div>
   <div v-if="theme == 'd2'" class="text-center mt-3">
-    Credits to Dimka-DJZLO at <a href="https://discord.gg/NvfftHY">Phrozen Keep</a> for the theme!</a>
+    Credits to Dimka-DJZLO at <a href="https://discord.gg/NvfftHY">Phrozen Keep</a> for the theme!
   </div>
 </div>
 `
@@ -592,6 +594,33 @@ export default {
       reader.onload = this.onFileLoad;
       reader.readAsArrayBuffer(event.target.files[0]);
       event.target.value = null;
+    },
+    maxGold() {
+      this.save.attributes.gold = this.save.header.level * 10000;
+      this.save.attributes.stashed_gold = 2500000
+    },
+    unlockQs() {
+      const self = this;
+      function update(difficulty, act, quest, attributes, amount) {
+        if (self.save.header[difficulty][act][quest].is_completed === false){
+          self.save.header[difficulty][act][quest].is_completed = true;
+          if (quest === "prison_of_ice"){
+            self.save.header[difficulty][act][quest].consumed_scroll = true;
+          } else {
+            for(let attribute of attributes) {
+              self.save.attributes[attribute] = (self.save.attributes[attribute] ?? 0) + amount;
+            }
+          }
+        }
+      }
+      for (const diff of ["quests_normal", "quests_nm", "quests_hell"]) {
+        update(diff, "act_i", "den_of_evil", ["unused_skill_points"], 1);
+        update(diff, "act_ii", "radaments_lair", ["unused_skill_points"], 1);
+        update(diff, "act_iii", "lam_esens_tome", ["unused_stats"], 5);
+        update(diff, "act_iii", "the_golden_bird", ["max_hp", "current_hp"], 20);
+        update(diff, "act_iv", "the_fallen_angel", ["unused_skill_points"], 2);
+        update(diff, "act_v", "prison_of_ice", null, null);
+      }
     },
     unlockHell() {
       for (var i of ["quests_normal", "quests_nm", "quests_hell"]) {

--- a/js/components/Stats.js
+++ b/js/components/Stats.js
@@ -43,7 +43,7 @@ export default {
     </div>
   </div>
   <div class="form-row">
-    <div class="col-md-2">
+    <div class="col-md-4">
       <label for="Life">Life</label>
       <div class="input-group">
         <input class="form-control" type="number" id="Life" v-model.number="save.attributes.current_hp" :min="min(6)"
@@ -55,7 +55,7 @@ export default {
           :max="max(7)" @input="change(7, save.attributes, 'max_hp')">
       </div>
     </div>
-    <div class="col-md-2">
+    <div class="col-md-4">
       <label for="Mana">Mana</label>
       <div class="input-group">
         <input class="form-control" type="number" id="Mana" v-model.number="save.attributes.current_mana" :min="min(8)"
@@ -65,6 +65,18 @@ export default {
         </div>
         <input class="form-control" type="number" id="MaxMana" v-model.number="save.attributes.max_mana" :min="min(9)"
           :max="max(9)" @input="change(9, save.attributes, 'max_mana')">
+      </div>
+    </div>
+    <div class="col-md-4">
+      <label for="Stamina">Stamina</label>
+      <div class="input-group">
+        <input class="form-control" type="number" id="Stamina" v-model.number="save.attributes.current_stamina" :min="min(6)"
+               :max="max(6)" @input="change(6, save.attributes, 'current_stamina')">
+        <div class="input-group-prepend input-group-append">
+          <div class="input-group-text">/</div>
+        </div>
+        <input class="form-control" type="number" id="MaxStamina" v-model.number="save.attributes.max_stamina" :min="min(7)"
+               :max="max(7)" @input="change(7, save.attributes, 'max_stamina')">
       </div>
     </div>
   </div>
@@ -97,7 +109,7 @@ export default {
         :min="min(4)" :max="max(4)" @input="change(4, save.attributes, 'unused_stats')">
     </div>
     <div class="col-md-2">
-      <label for="UnusedSkillPoints">Unused Skilled Points</label>
+      <label for="UnusedSkillPoints">Unused Skill Points</label>
       <input type="number" class="form-control" id="UnusedSkillPoints"
         v-model.number="save.attributes.unused_skill_points" :min="min(5)" :max="max(5)"
         @input="change(5, save.attributes, 'unused_skill_points')">


### PR DESCRIPTION
Partially addresses #47 and #32.

This change adds some new features and fixes several typos.

New Features: 
* Unlock skill/stat Qs button:
  * Finishes skill/stat quests, giving 12 skills, 15 stats, 60 life, and 30 all res.
  * Will only give reward if the quest hasn't already been completed.
* Max Gold button:
  * Gives max gold in stash (2.5 mil) and inventory (10k * clvl)  
* Stamina:
  * Added stamina to the stats screen
  * Also increases the width of the HP/Mana so 3-4 digit values are fully shown on smaller screens.
  
Fixes:
* Dangling anchor:
    * Removes duplicate closing anchor in the theme credits.
* Stats Typo:
    * `Unspent Skilled Points` -> `Unspent Skill Points`
* Overflow on Item:
    * Adds overflow (scrollbar) to inventory selection on Items
