### PR TITLE
Add Contextmenu and Set Skills Button

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -6,6 +6,27 @@
   border-radius: 0 !important;
 }
 
+div ul.context-menu {
+  top: 0;
+  left: 0;
+  margin: 0;
+  display: none;
+  list-style: none;
+  z-index: 10;
+  box-shadow: 0 3px 6px #000000;
+  border-radius: 6px;
+
+  width: 100px;
+  text-align: center;
+}
+
+ul.context-menu li:first-of-type {
+  margin-top: 4px;
+}
+ul.context-menu li:last-of-type {
+  margin-bottom: 4px;
+}
+
 .bg-light {
   opacity: .8;
   background-color: #303030 !important;

--- a/js/components/Mercenary.js
+++ b/js/components/Mercenary.js
@@ -6,13 +6,13 @@ export default {
   template: html`
 <div class="inventory">
   <span class="head">
-    <Item v-if="head" :item.sync="head" @click.native="onSelect(head)" /></span>
+    <Item v-if="head" :item.sync="head" @click.native="onSelect(head)" @contextmenu.prevent.stop="itemRC($event, head)"/></span>
   <span class="torso">
-    <Item v-if="torso" :item.sync="torso" @click.native="onSelect(torso)" /></span>
+    <Item v-if="torso" :item.sync="torso" @click.native="onSelect(torso)" @contextmenu.prevent.stop="itemRC($event, torso)"/></span>
   <span class="right-hand weapon">
-    <Item v-if="right_hand" :item.sync="right_hand" @click.native="onSelect(right_hand)" /></span>
+    <Item v-if="right_hand" :item.sync="right_hand" @click.native="onSelect(right_hand)" @contextmenu.prevent.stop="itemRC($event, right_hand)"/></span>
   <span class="left-hand weapon">
-    <Item v-if="left_hand" :item.sync="left_hand" @click.native="onSelect(left_hand)" /></span>
+    <Item v-if="left_hand" :item.sync="left_hand" @click.native="onSelect(left_hand)" @contextmenu.prevent.stop="itemRC($event, left_hand)"/></span>
 </div>
 `,
 components: {
@@ -20,6 +20,7 @@ components: {
 },
 props: {
   items: Array,
+  contextMenu: Object,
 },
 computed: {
   head() { return this.items.find(e => e.equipped_id === 1); },
@@ -38,6 +39,16 @@ computed: {
 methods: {
   onSelect(item) {
     this.$emit('item-selected', item);
+  },
+  itemRC($evt, item) {
+    if (item != null) {
+      this.contextMenu.showContextMenu($evt, item, [
+        {text: "Select"},
+        {text: "Copy"},
+        {text: "Share"},
+        {text: "Delete"}
+      ]);
+    }
   }
 }
 };

--- a/js/components/Skills.js
+++ b/js/components/Skills.js
@@ -2,19 +2,45 @@ import html from '../html.js';
 
 export default {
   template: html`
-<div class="form-row">
-  <div class="col-md-4" v-for="i in 3">
-    <div class="row">
-      <div class="col-md-6" v-for="j in 10">
-        <label :for="'Skill' + i + '_' + j">{{save.skills[(i - 1) * 10 + (j - 1)].name}}</label>
-        <input type="number" class="form-control" :id="'Skill' + i + '_' + j" min="0" max="20"
-          v-model.number="save.skills[(i - 1) * 10 + (j - 1)].points">
+<div>
+  <div class="form-row">
+    <div class="col-md-4" v-for="i in 3">
+      <div class="row">
+        <div class="col-md-6" v-for="j in 10">
+          <label :for="'Skill' + i + '_' + j">{{save.skills[(i - 1) * 10 + (j - 1)].name}}</label>
+          <input type="number" class="form-control" :id="'Skill' + i + '_' + j" min="0" max="20"
+            v-model.number="save.skills[(i - 1) * 10 + (j - 1)].points">
+        </div>
       </div>
+    </div>
+  </div>
+  <br />
+  <div class="form-row">
+    <div class="input-group">
+      <div class="input-group-prepend">
+        <button type="button" class="btn btn-secondary" @click="setAll()">Set All To</button>
+      </div>
+      <input type="number" min="0" max="20" v-model="allSkills"/>
     </div>
   </div>
 </div>
 `,
 props: {
   save: Object,
+},
+data() {
+  return {
+    allSkills: null
+  }
+},
+methods: {
+    setAll() {
+      if(this.allSkills === null || this.allSkills === undefined)
+        return;
+      for (const skill of this.save.skills) {
+        skill.points = this.allSkills;
+      }
+      this.allSkills = null;
+    }
 }
 };

--- a/js/components/inventory/Equipped.js
+++ b/js/components/inventory/Equipped.js
@@ -6,11 +6,11 @@ export default {
   template: html`
 <div class="inventory">
   <span class="head" v-on:drop="drop($event, 1)"  v-on:dragover="dragover" v-on:dragenter="dragenter($event, 1)" v-on:dragleave="dragleave($event, 1)"><div class="layer" :id="id + '-1'"></div>
-    <Item v-if="head" :item.sync="head" @click.native="onSelect(head)" /></span>
+    <Item v-if="head" :item.sync="head" @click.native="onSelect(head)" @contextmenu.prevent.stop="itemRC($event, head)"></span>
   <span class="neck" v-on:drop="drop($event, 2)"  v-on:dragover="dragover" v-on:dragenter="dragenter($event, 2)" v-on:dragleave="dragleave($event, 2)"><div class="layer" :id="id + '-2'"></div>
-    <Item v-if="neck" :item.sync="neck" @click.native="onSelect(neck)" /></span>
+    <Item v-if="neck" :item.sync="neck" @click.native="onSelect(neck)" @contextmenu.prevent.stop="itemRC($event, neck)"/></span>
   <span class="torso" v-on:drop="drop($event, 3)"  v-on:dragover="dragover" v-on:dragenter="dragenter($event, 3)" v-on:dragleave="dragleave($event, 3)"><div class="layer" :id="id + '-3'"></div>
-    <Item v-if="torso" :item.sync="torso" @click.native="onSelect(torso)" /></span>
+    <Item v-if="torso" :item.sync="torso" @click.native="onSelect(torso)" @contextmenu.prevent.stop="itemRC($event, torso)"/></span>
   <span class="right-tab tabs">
     <div class="btn-group" role="group">
       <button type="button" class="tab btn btn-secondary" :class="{ active: !alt_displayed }"
@@ -20,10 +20,10 @@ export default {
     </div>
   </span>
   <span v-show="!alt_displayed" class="right-hand weapon" v-on:drop="drop($event, 4)"  v-on:dragover="dragover" v-on:dragenter="dragenter($event, 4)" v-on:dragleave="dragleave($event, 4)"><div class="layer" :id="id + '-4'"></div>
-    <Item v-if="right_hand" :item.sync="right_hand" @click.native="onSelect(right_hand)" />
+    <Item v-if="right_hand" :item.sync="right_hand" @click.native="onSelect(right_hand)" @contextmenu.prevent.stop.stop="itemRC($event, right_hand)"/>
   </span>
   <span v-show="alt_displayed" class="alt-right-hand weapon" v-on:drop="drop($event, 11)"  v-on:dragover="dragover" v-on:dragenter="dragenter($event, 11)" v-on:dragleave="dragleave($event, 11)"><div class="layer" :id="id + '-11'"></div>
-    <Item v-if="alt_right_hand" :item.sync="alt_right_hand" @click.native="onSelect(alt_right_hand)" />
+    <Item v-if="alt_right_hand" :item.sync="alt_right_hand" @click.native="onSelect(alt_right_hand)" @contextmenu.prevent.stop="itemRC($event, alt_right_hand)"/>
   </span>
   <span class="left-tab tabs">
     <div class="btn-group" role="group">
@@ -34,21 +34,21 @@ export default {
     </div>
   </span>
   <span v-show="!alt_displayed" class="left-hand weapon" v-on:drop="drop($event, 5)"  v-on:dragover="dragover" v-on:dragenter="dragenter($event, 5)" v-on:dragleave="dragleave($event, 5)"><div class="layer" :id="id + '-5'"></div>
-    <Item v-if="left_hand" :item.sync="left_hand" @click.native="onSelect(left_hand)" />
+    <Item v-if="left_hand" :item.sync="left_hand" @click.native="onSelect(left_hand)" @contextmenu.prevent.stop="itemRC($event, left_hand)"/>
   </span>
   <span v-show="alt_displayed" class="alt-left-hand weapon" v-on:drop="drop($event, 12)"  v-on:dragover="dragover" v-on:dragenter="dragenter($event, 12)" v-on:dragleave="dragleave($event, 12)"><div class="layer" :id="id + '-12'"></div>
-    <Item v-if="alt_left_hand" :item.sync="alt_left_hand" @click.native="onSelect(alt_left_hand)" />
+    <Item v-if="alt_left_hand" :item.sync="alt_left_hand" @click.native="onSelect(alt_left_hand)" @contextmenu.prevent.stop="itemRC($event, alt_left_hand)"/>
   </span>
   <span class="right-finger ring" v-on:drop="drop($event, 6)"  v-on:dragover="dragover" v-on:dragenter="dragenter($event, 6)" v-on:dragleave="dragleave($event, 6)"><div class="layer" :id="id + '-6'"></div>
-    <Item v-if="right_finger" :item.sync="right_finger" @click.native="onSelect(right_finger)" /></span>
+    <Item v-if="right_finger" :item.sync="right_finger" @click.native="onSelect(right_finger)" @contextmenu.prevent.stop="itemRC($event, right_finger)"/></span>
   <span class="left-finger ring" v-on:drop="drop($event, 7)"  v-on:dragover="dragover" v-on:dragenter="dragenter($event, 7)" v-on:dragleave="dragleave($event, 7)"><div class="layer" :id="id + '-7'"></div>
-    <Item v-if="left_finger" :item.sync="left_finger" @click.native="onSelect(left_finger)" /></span>
+    <Item v-if="left_finger" :item.sync="left_finger" @click.native="onSelect(left_finger)" @contextmenu.prevent.stop="itemRC($event, left_finger)"/></span>
   <span class="waist" v-on:drop="drop($event, 8)"  v-on:dragover="dragover" v-on:dragenter="dragenter($event, 8)" v-on:dragleave="dragleave($event, 8)"><div class="layer" :id="id + '-8'"></div>
-    <Item v-if="waist" :item.sync="waist" @click.native="onSelect(waist)" /></span>
+    <Item v-if="waist" :item.sync="waist" @click.native="onSelect(waist)" @contextmenu.prevent.stop="itemRC($event, waist)"/></span>
   <span class="feet" v-on:drop="drop($event, 9)"  v-on:dragover="dragover" v-on:dragenter="dragenter($event, 9)" v-on:dragleave="dragleave($event, 9)"><div class="layer" :id="id + '-9'"></div>
-    <Item v-if="feet" :item.sync="feet" @click.native="onSelect(feet)" /></span>
+    <Item v-if="feet" :item.sync="feet" @click.native="onSelect(feet)" @contextmenu.prevent.stop="itemRC($event, feet)"/></span>
   <span class="hands" v-on:drop="drop($event, 10)"  v-on:dragover="dragover" v-on:dragenter="dragenter($event, 10)" v-on:dragleave="dragleave($event, 10)"><div class="layer" :id="id + '-10'"></div>
-    <Item v-if="hands" :item.sync="hands" @click.native="onSelect(hands)" /></span>
+    <Item v-if="hands" :item.sync="hands" @click.native="onSelect(hands)" @contextmenu.prevent.stop="itemRC($event, hands)"/></span>
 </div>
 `,
 components: {
@@ -76,6 +76,7 @@ computed: {
 props: {
   items: Array,
   id: String,
+  contextMenu: Object,
 },
 methods: {
   setAltDisplayed(value) {
@@ -83,6 +84,16 @@ methods: {
   },
   onSelect(item) {
     this.$emit('item-selected', item);
+  },
+  itemRC($evt, item) {
+    if (item != null) {
+      this.contextMenu.showContextMenu($evt, item, [
+        {text: "Select"},
+        {text: "Copy"},
+        {text: "Share"},
+        {text: "Delete"}
+      ]);
+    }
   },
   dragover(event) {
     event.preventDefault();

--- a/js/components/inventory/Grid.js
+++ b/js/components/inventory/Grid.js
@@ -6,10 +6,13 @@ export default {
   template: html`
 <div class="grid" :class="gridClass">
   <div class="h-1 cell" :class="'y-' + (h - 1)" v-for="h in height">
-    <div :id="id + '-' + w + '-' + h" class="w-1 h-1 y-0 cell" :class="'x-' + (w - 1)" v-for="w in width" v-on:drop="drop($event, w, h)" v-on:dragover="dragover" v-on:dragenter="dragenter($event, w, h)" v-on:dragleave="dragleave($event, w, h)">
+    <div :id="id + '-' + w + '-' + h" class="w-1 h-1 y-0 cell" :class="'x-' + (w - 1)" v-for="w in width" 
+         v-on:drop="drop($event, w, h)" v-on:dragover="dragover" v-on:dragenter="dragenter($event, w, h)" 
+         v-on:dragleave="dragleave($event, w, h)" @contextmenu.prevent.stop="gridRC($event, w, h)">
     </div>
   </div>
-  <Item v-for="(item, idx) in items" :key="idx" :item.sync="item" @click.native="onSelect(item)" />
+  <Item v-for="(item, idx) in items" :key="idx" :item.sync="item" @click.native="onSelect(item)" 
+        @contextmenu.prevent.stop="itemRC($event, item)"/>
 </div>
 `,
 components: {
@@ -21,6 +24,7 @@ props: {
   height: Number,
   page: Number,
   id: String,
+  contextMenu: Object,
 },
 computed: {
   gridClass() {
@@ -67,6 +71,19 @@ methods: {
       },
       type: 'dragleave'
     });
+  },
+  itemRC($evt, item) {
+    this.contextMenu.showContextMenu($evt, item, [
+        {text: "Select"},
+        {text: "Copy"},
+        {text: "Share"},
+        {text: "Delete"}
+    ])
+  },
+  gridRC($evt, w, h) {
+    this.contextMenu.showContextMenu($evt, [w - 1, h - 1], [
+        {text: "Paste At"}
+    ])
   },
   drop(event, x, y) {
     event.preventDefault();


### PR DESCRIPTION
This PR adds two things:

A bottom row is added to the skills page that allows the user to set all skills from any value 0-20.

It also adds a right click contextmenu to the inventory editor screen. These allow the user to share, select, copy, delete, and paste at (where applicable). It will attempt to paste the item at the grid square (does not work on equipment) selected otherwise will just use the default paste behavior.